### PR TITLE
feat(nix): added home-manager module and some changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ Create `~/.config/nsticky/config.toml` to auto-sticky windows matching rules:
 
 ```toml
 [sticky.firefox]
-app_id = "firefox"
+app-id = "firefox"
 
 [sticky.kitty]
-app_id = "kitty"
+app-id = "kitty"
 title = ".*server.*"
 
 [sticky.gmail]
@@ -98,6 +98,33 @@ title = ".*Gmail.*"
 - `app_id` and `title` are AND logic (both must match)
 - Use regex patterns
 - If only one field is specified, it matches any value
+
+You can also configure nsticky from the home-manager module:
+```nix
+{ inputs, ... }:
+
+{
+  imports = [
+    inputs.nsticky.homeModules.default
+  ];
+
+  programs.sticky = {
+    enable = true;
+    settings = {
+      sticky = {
+        firefox.app-id = "firefox";
+
+        kitty = {
+          app-id = "kitty";
+          title = ".*server.*";
+        };
+
+        gmail.title = ".*Gmail.*";
+      };
+    };
+  };
+}
+```
 
 ---
 

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,11 @@
 
       modules = [ ];
 
+      flake.homeModules = rec {
+        default = nsticky;
+        nsticky = ./nix/module.nix;
+      };
+
       perSystem =
         {
           self',
@@ -46,27 +51,7 @@
 
           packages = {
             default = self'.packages.nsticky;
-
-            nsticky = pkgs.rustPlatform.buildRustPackage {
-              pname = "nsticky";
-              version = "0.1.0";
-              src = ./.;
-              cargoLock.lockFile = ./Cargo.lock;
-
-              meta = {
-                description = "A sticky windows manager CLI tool for Niri";
-                homepage = "https://github.com/lonerOrz/nsticky";
-                mainProgram = "nsticky";
-                license = lib.licenses.bsd3;
-                maintainers = with lib.maintainers; [ lonerOrz ];
-                platforms = [
-                  "x86_64-linux"
-                  "aarch64-linux"
-                  "x86_64-darwin"
-                  "aarch64-darwin"
-                ];
-              };
-            };
+            nsticky = pkgs.callPackage ./nix/package.nix { };
           };
 
           devShells.default = pkgs.mkShell {

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,0 +1,74 @@
+{ lib, pkgs, config, ... }:
+
+let
+  inherit (lib)
+  mkOption
+  mkEnableOption
+  types
+  mkIf
+  literalExpression
+  ;
+
+  cfg = config.programs.nsticky;
+  tomlFormat = pkgs.formats.toml { };
+in
+{
+  options.programs.nsticky = {
+    enable = mkEnableOption "nsticky";
+    package = mkOption {
+      type = with types; nullOr package;
+      default = pkgs.callPackage ./package.nix { };
+      description = ''
+        The nsticky package to use.
+      '';
+    };
+    
+    settings = mkOption {
+      inherit (tomlFormat) type;
+      default = { };
+      example = literalExpression ''
+        {
+          sticky = {
+          firefox.app-id = "firefox";
+
+          kitty = {
+            app-id = "kitty";
+            title = ".*server.*";
+          };
+
+          gmail.title = ".*Gmail.*";
+        }
+      '';
+      description = ''
+        Configuration written to
+        {file}`$XDG_CONFIG_HOME/nsticky/config.toml`.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = mkIf (cfg.package != null ) [
+      cfg.package
+    ];
+
+    xdg.configFile."nsticky/config.toml" = mkIf (cfg.settings != { }) {
+      source = tomlFormat.generate "sticky-config" cfg.settings;
+    };
+
+    systemd.user.services.nsticky = {
+      Unit = {
+        Description = "nsticky service";
+        PartOf = [ config.wayland.systemd.target ];
+        After = [ config.wayland.systemd.target ];
+      };
+
+      Service = {
+        Type = "simple";
+        ExecStart = "${lib.getExe cfg.package}";
+        Restart = "on-failure";
+      };
+
+      Install.WantedBy = [ config.wayland.systemd.target ];
+    };
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  rustPlatform,
+}:
+
+let
+  cargoToml = fromTOML (builtins.readFile ../Cargo.toml);
+in
+rustPlatform.buildRustPackage {
+  pname = cargoToml.package.name;
+  version = cargoToml.package.version;
+  src = ../.;
+  cargoLock.lockFile = ../Cargo.lock;
+
+  meta = {
+    description = "A sticky windows manager CLI tool for Niri";
+    homepage = "https://github.com/lonerOrz/nsticky";
+    mainProgram = "nsticky";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ lonerOrz ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+  };
+}


### PR DESCRIPTION
This PR adds a home-manager module for nsticky:
- `programs.nsticky.enable`: enable the module
- `programs.nsticky.package`: package to use for nsticky
- `programs.nsticky.settings`: attrSet converted into toml for the config.

Once enabled, the module will:
- Install nsticky with home.packages to make it available in PATH
- Create and enable a systemd service for nsticky
- Write nsticky's config if any if defined in `programs.nsticky.settings`

Additionally, this PR also moves nsticky's package to it's own file in the `nix` directory (I'll admit it I couldn't get the module to refer to the package for `programs.nsticky.package` when it was located directly in `flake.nix`) and changes the nix package's to `0.3.0` since it was left on `0.1.0`.